### PR TITLE
Add conflict with scheb/two-factor-bundle 4.7.0 (broken 2FA in frontend)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "doctrine/orm": "<2.4",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
+        "scheb/two-factor-bundle": ">=4.7.0",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
See https://github.com/contao/contao/pull/707

Somehow 2FA is broken with `scheb/two-factor-bundle` in version `4.7.0` (never ending redirects after submitting the verify code). I need to investigate why.
