### PR TITLE
Revert "Add conflict with scheb/two-factor-bundle 4.7.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "doctrine/orm": "<2.4",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
-        "scheb/two-factor-bundle": ">=4.7.0",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
Broken 2FA in frontend, see #6
This reverts commit f450dd170bb31d44e82622d487788914f8bce648 and should be merged after https://github.com/contao/contao/pull/711 has been released.