### PR TITLE
Do not allow tecnickcom/tcpdf 6.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
+        "tecnickcom/tcpdf": "6.3.*",
         "twig/twig": "2.7.0"
     }
 }


### PR DESCRIPTION
Version 6.3.0 through 6.3.2 (the latest version) of `tecnickcom/tcpdf` (used by the `contao/tcpdf-bundle` of course) has a serious issue where files used in the PDF get deleted after generation: https://github.com/tecnickcom/TCPDF/issues/158