### PR TITLE
Revert the knp-time-bundle conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/doctrine-migrations-bundle": "<1.1",
         "doctrine/orm": "<2.4",
         "doctrine/persistence": "1.3.2",
-        "knplabs/knp-time-bundle": "1.9.0 || 1.11.0",
+        "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
         "monolog/monolog": ">=2",
         "symfony/finder": "3.4.7 || 4.0.7",


### PR DESCRIPTION
This PR reverts the changes from 87a15666b34d7813f95c75438ba0f9c2ba525619 as Contao 4.8.8 has been released today (see contao/contao#1140).