### PR TITLE
Add conflict with scheb/2fa-bundle >=5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
         "monolog/monolog": ">=2",
+        "scheb/2fa-bundle": ">=5.4",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
See https://github.com/contao/contao/pull/2680. Has to be reverted, when https://github.com/contao/contao/pull/2680 is released.