### PR TITLE
Remove monolog 2 conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
-        "monolog/monolog": ">=2",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
This should no longer be needed, see https://github.com/contao/contao/issues/978#issuecomment-559522920

And we need to remove this in order to allow monolog 2 to be installed with Contao 4.11