### PR TITLE
Add conflict for lcobucci/jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "doctrine/orm": "<2.4",
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-time-bundle": "1.9.0",
+        "lcobucci/jwt": "^4.1",
         "lexik/maintenance-bundle": "2.1.4",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7",


### PR DESCRIPTION
See https://github.com/contao/contao-manager/issues/625#issue-797746482

Until this is resolved on the Composer Cloud Resolver a conflict could be added here, so that `lcobucci/jwt: 4.1.*` will not be installed.

_Note:_ this only affects installations using the Contao Manager together with the Composer Cloud Resolver. Otherwise Composer will of course not try to install  `lcobucci/jwt: 4.1.*`, if your environment does not have `ext-sodium` enabled.