### PR TITLE
Add terminal42/escargot 1.0.3 & 1.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
+        "terminal42/escargot": "1.0.3 || 1.0.4",
         "twig/twig": "2.7.0"
     }
 }


### PR DESCRIPTION
Version `1.0.3` (and `1.0.4`) of `terminal42/escargot` registers a custom error handler that is never unregistered and thus can cause the crawler to break - since then every warning, notice or even silenced error will throw an exception. Until either https://github.com/contao/contao/pull/2894 or https://github.com/terminal42/escargot/pull/21 is merged and released we could add a conflict for the affected `terminal42/escargot` versions.

@Toflar or would going back to `1.0.2` cause more problems than it solves potentially?