### PR TITLE
Disallow installation of Sf FrameworkBundle 5.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
         "symfony/finder": "3.4.7 || 4.0.7",
-        "symfony/framework-bundle": "4.2.7",
+        "symfony/framework-bundle": "4.2.7 || > 5.2.5",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",


### PR DESCRIPTION
see https://github.com/symfony/symfony/issues/40618
Should be set to an exact version once this is fixed in Symfony