### PR TITLE
Add conflict for doctrine/dbal 2.13.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "conflict": {
-        "doctrine/dbal": "2.9.* <2.9.3",
+        "doctrine/dbal": "2.9.* <2.9.3 || 2.13.0",
         "doctrine/doctrine-migrations-bundle": "<1.1",
         "doctrine/orm": "<2.4",
         "doctrine/persistence": "1.3.2",


### PR DESCRIPTION
do not use `doctrine/dbal` in version 2.13.0