### PR TITLE
Add symfony/http-foundation: 4.4.27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "lexik/maintenance-bundle": "2.1.4",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
+        "symfony/http-foundation": "4.4.27",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",


### PR DESCRIPTION
Due to type error in the `Request` class introduced in `4.4.27`. See https://github.com/symfony/symfony/pull/42289