### PR TITLE
Add a conflict for symfony/translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/http-foundation": "4.4.27",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
+        "symfony/translation": "5.3.8",
         "symfony/twig-bundle": "4.1.0",
         "twig/twig": "2.7.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27",
+        "symfony/mailer": "5.3.8",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/translation": "5.3.8",


### PR DESCRIPTION
It seems that Symfony has messed up an upstream merge and now symfony/translation 5.3.8 no longer is PSR-4 compatible. This breaks Contao from version 4.9 upwards.