### PR TITLE
Remove the latest conflicts again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,8 @@
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27",
-        "symfony/mailer": "5.3.8",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
-        "symfony/translation": "4.4.31 || 5.3.8",
         "symfony/twig-bundle": "4.1.0",
         "twig/twig": "2.7.0"
     }


### PR DESCRIPTION
Symfony has removed the broken tags, therefore we could remove the conflicts again. @contao/developers WDYT?