### PR TITLE
Add Roave Security Advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "homepage": "https://github.com/leofeyer"
         }
     ],
+    "require": {
+        "roave/security-advisories": "dev-latest"
+    },
     "conflict": {
         "doctrine/dbal": "2.9.* <2.9.3",
         "doctrine/doctrine-migrations-bundle": "<1.1",


### PR DESCRIPTION
Since Composer 2.2 has less memory problems and its much faster we can increase the security by simple add this repository. 

initial discussion on slack: https://contao.slack.com/archives/CLBDSRMS6/p1638474791080000