### PR TITLE
Add conflict for symfony/http-kernel 5.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27",
+        "symfony/http-kernel": "5.4.1",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",


### PR DESCRIPTION
With the changes of https://github.com/symfony/http-kernel/commit/56df45cd80512e6bb69ea96095e5e430448d0640 which was released in Symfony `5.4.1` logins via `http://` do not work anymore. See also https://github.com/symfony/symfony/issues/44546