### PR TITLE
Add doctrine/dbal 3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "conflict": {
-        "doctrine/dbal": "2.9.* <2.9.3",
+        "doctrine/dbal": "2.9.* <2.9.3 || 3.3.0",
         "doctrine/doctrine-migrations-bundle": "<1.1",
         "doctrine/orm": "<2.4",
         "doctrine/persistence": "1.3.2",


### PR DESCRIPTION
See https://github.com/contao/contao/issues/3980

I think it's better to immediately add that conflict, as it reflects poorly on the performance of Contao 4.13-RC.