### PR TITLE
Add a conflict for symfony/web-profiler-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
-        "symfony/web-profiler-bundle": ">=6.1, <6.1.2",
+        "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/twig": "2.7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
-        "symfony/web-profiler-bundle": ">=6.0, <6.1.2",
+        "symfony/web-profiler-bundle": ">=6.1, <6.1.2",
         "twig/twig": "2.7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
+        "symfony/web-profiler-bundle": ">=6.0, <6.1.2",
         "twig/twig": "2.7.0"
     }
 }


### PR DESCRIPTION
This adds a conflict for `symfony/web-profiler-bundle` due to https://github.com/symfony/symfony/pull/46650 - see https://github.com/contao/manager-plugin/issues/48

Once the `contao/manager-plugin` unlocks Symfony 6, the fixed version of `symfony/web-profiler-bundle` can automatically be installed (without removing this conflict).