### PR TITLE
Add more conflicts for symfony/http-foundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "lexik/maintenance-bundle": "2.1.4",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
-        "symfony/http-foundation": "4.4.27",
+        "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",


### PR DESCRIPTION
In the newest Symfony versions the [`Content-Type` auto-detection for `BinaryFileResponse` is broken](https://github.com/symfony/symfony/pull/47746), resulting in every response (where you do not set the `Content-Type` manually) having a `Content-Type` of `text/html`.

This is also reproducible in Contao:

1. Execute `contao:automator purgeImageCache`.
2. Open the developer tools of your browser and head to the network tab.
3. Refresh a front end page with images (produced by image sizes).
4. Inspect the response headers for the newly generated image files - they will have `text/html` instead of `image/jpeg` etc. for their `Content-Type`.

While this in particular is not a huge issue, as browsers react quite lenient here apparently (though the preview of the developer tools will not show the image properly), it might cause issues elsewhere, e.g. when trying to download the debug CSV of the crawler (haven't specifically tested that).