### PR TITLE
Conflict with symfony/dependency-injection 6.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
-        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0",
+        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",


### PR DESCRIPTION
The fix from 3b75e0ac5af1f765951d4978ea02ed491aeb81b3 was not merged upstream yet and so the new 6.2.1 version seems to be affected too.