### PR TITLE
Add `"php-http/discovery": "1.15.0"`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
         "lcobucci/jwt": ">=4.2.0",
+        "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",


### PR DESCRIPTION
Updating `php-http/discovery` to `1.15.0` (and then confirming the execution of its composer plugin) currently results in an endless composer update loop. See https://github.com/php-http/discovery/issues/211