### PR TITLE
Add conflict for `php-http/discovery:1.16.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
         "lcobucci/jwt": ">=4.2.0",
-        "php-http/discovery": "1.15.0",
+        "php-http/discovery": "1.15.0 || 1.16.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",


### PR DESCRIPTION
There is a regression in `php-http/discovery:1.16.0` which was released an hour ago (https://github.com/php-http/message/pull/152#issuecomment-1550923764).