### PR TITLE
Remove `php-http/message` conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "lexik/maintenance-bundle": "2.1.4",
         "lcobucci/jwt": ">=4.2.0",
         "php-http/discovery": "1.15.0",
-        "php-http/message": "1.16.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",


### PR DESCRIPTION
Original [error](https://github.com/php-http/message/pull/152#issuecomment-1550923764) fixed via https://github.com/FriendsOfSymfony/FOSHttpCache/pull/543.