### PR TITLE
Use open ended conflict with `league/flysystem-bundle`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/orm": "<2.4",
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-time-bundle": "1.9.0",
-        "league/flysystem-bundle": "3.3.0",
+        "league/flysystem-bundle": ">=3.3.0",
         "lexik/maintenance-bundle": "2.1.4",
         "lcobucci/jwt": ">=4.2.0",
         "php-http/discovery": "1.15.0",


### PR DESCRIPTION
Since this error is something that (likely) won't get fixed in `league/flysystem-bundle` itself we should use an open ended conflict instead, otherwise this error will occur again if `league/flysystem-bundle` happens to release a new version for unrelated reasons, before Contao can release fixed versions.