### PR TITLE
Conflict with `symfony/framework-bundle: 5.4.30`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
-        "symfony/framework-bundle": "4.2.7 || 5.2.6",
+        "symfony/framework-bundle": "4.2.7 || 5.2.6 || 5.4.30",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
After upgrading to `symfony/framework-bundle: 5.4.30` the `prod` logs will be flooded with deprecation messages, whenever an `ERROR` or `CRITICAL` log entry happens to be logged (`fingers_crossed`). This can cause high memory and storage loads.