### PR TITLE
Add more conflicts for `symfony/framework-bundle`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
-        "symfony/framework-bundle": "4.2.7 || 5.2.6 || 5.4.30",
+        "symfony/framework-bundle": "4.2.7 || 5.2.6 || >=5.4.30",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
-        "symfony/framework-bundle": "4.2.7 || 5.2.6 || >=5.4.30,<6@dev || >=6.3.6,<7@dev",
+        "symfony/framework-bundle": "4.2.7 || 5.2.6 || 5.4.30 - 5.4.31 || 6.3.6 - 6.3.8"
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
-        "symfony/framework-bundle": "4.2.7 || 5.2.6 || >=5.4.30",
+        "symfony/framework-bundle": "4.2.7 || 5.2.6 || >=5.4.30,<6@dev || >=6.3.6,<7@dev",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",


### PR DESCRIPTION
Symfony `5.4.31` was released today, which causes #52 again. I think until we got to the bottom of this we need to use an open ended conflict.