### PR TITLE
Add a conflict for `symfony/routing: 6.4.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/framework-bundle": "4.2.7 || 5.2.6 || 5.4.30 - 5.4.31 || 6.3.6 - 6.3.8",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
+        "symfony/routing": "6.4.0",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",


### PR DESCRIPTION
If you have controllers like this in your App or within extensions:

```php
// src/Controller/FoobarController.php
namespace App\Controller;

use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\Routing\Annotation\Route;

#[Route('/foobar', self::class)]
class FoobarController
{
    public function __invoke(): Response
    {
        return new Response('Hello World!');
    }
}
```

updating to `symfony/routing: 6.4.0` will cause an error. See https://github.com/symfony/symfony/issues/52801

Though I guess since Contao itself does not use route definitions this way, we might not want to add a conflict?