### PR TITLE
Remove recent `symfony/framework-bundle` conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "1.15.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
-        "symfony/framework-bundle": "4.2.7 || 5.2.6 || 5.4.30 - 5.4.32 || 6.3.6 - 6.3.9",
+        "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
         "symfony/http-kernel": "5.4.1 || 5.4.12",
         "symfony/routing": "6.4.0",


### PR DESCRIPTION
Now that Contao 4.13.35 and 5.2.7 have been released we can remove the conflicts introduced in https://github.com/contao/conflicts/pull/52, https://github.com/contao/conflicts/pull/53 & https://github.com/contao/conflicts/pull/56