### PR TITLE
Add conflict for `twig/twig` `3.9.*`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
-        "twig/twig": "2.7.0 || 3.9.*"
+        "twig/twig": "2.7.0 || 3.9.0 || 3.9.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
-        "twig/twig": "2.7.0 || 3.9.0"
+        "twig/twig": "2.7.0 || 3.9.0 || 3.9.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
-        "twig/twig": "2.7.0 || 3.9.0 || 3.9.1"
+        "twig/twig": "2.7.0 || 3.9.*"
     }
 }


### PR DESCRIPTION
https://github.com/contao/contao/issues/7121

Or should we conflict `3.9.*` in general as long as we have not released https://github.com/contao/contao/pull/7122 ?