### PR TITLE
Update conflict with twig/twig to 3.9.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
-        "twig/twig": "2.7.0 || 3.9.0"
+        "twig/twig": "2.7.0 || 3.9.*"
     }
 }


### PR DESCRIPTION
Changing the conflict to just ``3.9.0`` as done in this commit won't help as twig already released a 3.9.1 https://github.com/contao/conflicts/commit/de9d3417cf441134166f2c09650a358375eae9b5

Twig purposefully changed all functions to internal in 3.9.x, meaning that https://github.com/contao/contao/issues/7121 will always happen for this version:
See https://github.com/twigphp/Twig/blob/3.x/doc/deprecated.rst#extensions