### PR TITLE
Conflict with Twig 3.9.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
-        "twig/twig": "2.7.0 || 3.9.0"
+        "twig/twig": "2.7.0 || 3.9.*"
     }
 }


### PR DESCRIPTION
It looks like there are still some issues with Twig 3.9.

At least the `PhpTemplateProxyNode` needs to be updated as well. PR will follow.