### PR TITLE
Conflict with twig/intl-extra 3.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
+        "twig/intl-extra": "3.9.0",
         "twig/twig": "2.7.0 || 3.9.*"
     }
 }


### PR DESCRIPTION
As `twig/intl-extra` has the wrong dependency on `twig/twig` in version 3.9.0 (see https://github.com/twigphp/intl-extra/commit/39865e5d13165016a8e7ab8cc648ad2f7aa4b639 ) we have to conflict with it as well to prevent errors like `Call to undefined method Twig\Extension\CoreExtension::dateConverter()`.