### PR TITLE
Add conflict with twig 3.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/intl-extra": "3.9.0",
-        "twig/twig": "2.7.0 || 3.9.0"
+        "twig/twig": "2.7.0 || 3.9.0 || 3.10.0"
     }
 }


### PR DESCRIPTION
The recently released twig version adds new deprecations:

https://github.com/twigphp/Twig/compare/v3.9.3...v3.10.0

```In EscaperExtension.php line 127:                                            
You must call "setEnvironment()" before calling "Twig\Extension\EscaperExtension::setEscaper()".
```