### PR TITLE
Add a conflict for `twig/twig` `3.10.*`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/intl-extra": "3.9.0",
-        "twig/twig": "2.7.0 || 3.9.0 || 3.10.0"
+        "twig/twig": "2.7.0 || 3.9.0 || 3.10.*"
     }
 }


### PR DESCRIPTION
We might need to fix [this](https://github.com/twigphp/Twig/issues/4087) in Contao (depending on whether this will be considered a BC break by Twig or not). Until then we need to conflict with `twig/twig: 3.10.*`.