### PR TITLE
Revert the Twig 3.10.* conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/intl-extra": "3.9.0",
-        "twig/twig": "2.7.0 || 3.9.0 || 3.10.*"
+        "twig/twig": "2.7.0 || 3.9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/twig-bundle": "4.1.0",
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/intl-extra": "3.9.0",
-        "twig/twig": "2.7.0 || 3.9.0"
+        "twig/twig": "2.7.0 || 3.9.0 || 3.10.0 || 3.10.1"
     }
 }


### PR DESCRIPTION
We should remove the conflict with the open version constraint once the issue was fixed.
See #69 and #70

With https://github.com/twigphp/Twig/pull/4088 this should get fixed probably.