### PR TITLE
Add a conflict for `symfony/http-kernel` `6.4.9`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",
         "symfony/framework-bundle": "4.2.7 || 5.2.6",
         "symfony/http-foundation": "4.4.27 || 4.4.46 || 5.4.13 || 6.0.13 || 6.1.5",
-        "symfony/http-kernel": "5.4.1 || 5.4.12",
+        "symfony/http-kernel": "5.4.1 || 5.4.12 || 6.4.9",
         "symfony/routing": "6.4.0",
         "symfony/security": "3.3.17 || 3.4.7 || 3.4.8 || 3.4.11",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",


### PR DESCRIPTION
Currently the following error occurs when installing/updating Contao 5:

```
The "contao_manager.plugin_loader" service is synthetic, it needs to be set at boot time before it can be used.
```

Downgrading `symfony/http-kernel` fixes the issue.