### PR TITLE
Add a conflict for web-auth/webauthn-symfony-bundle 5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "symfony/web-profiler-bundle": "6.1.* <6.1.2",
         "twig/intl-extra": "3.9.0",
         "twig/twig": "2.7.0 || 3.9.0 || 3.10.0 || 3.10.1",
-        "web-auth/webauthn-symfony-bundle": "5.1.* <5.1.3"
+        "web-auth/webauthn-symfony-bundle": "5.1.* <5.1.3 || 5.2.0"
     }
 }


### PR DESCRIPTION
See https://github.com/web-auth/webauthn-framework/pull/707

```
In DefinitionErrorExceptionPass.php line 48:

Cannot autowire service "Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener": argument "$userProvider" of method "__construct()"
references interface "Symfony\Component\Security\Core\User\UserProviderInterface" but no such service exists. You should maybe alias this interface to
one of these existing services: "security.user_providers", "contao.security.backend_user_provider", "contao.security.frontend_user_provider".
```
