### PR TITLE
Add conflict for scheb/2fa-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "league/flysystem-bundle": "3.3.0 || 3.7.0",
         "lexik/maintenance-bundle": "2.1.4",
         "php-http/discovery": "1.15.0",
+        "scheb/2fa-bundle": "7.14.0 || 8.6.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "symfony/event-dispatcher": "6.4.36 || 7.4.8",
         "symfony/finder": "3.4.7 || 4.0.7 || 5.4.26 || 6.2.13 || 6.3.2",


### PR DESCRIPTION
2FA does not work in Contao 5 with `scheb/2fa-bundle` in `7.14.0` or `8.6.0`