### PR TITLE
Remove the `league/flysystem-bundle` conflict again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-menu-bundle": "3.4.0",
         "knplabs/knp-time-bundle": "1.9.0",
-        "league/flysystem-bundle": "3.3.0 || 3.7.0",
+        "league/flysystem-bundle": "3.3.0",
         "lexik/maintenance-bundle": "2.1.4",
         "php-http/discovery": "1.15.0",
         "scheb/2fa-bundle": "7.14.0 || 8.6.0",


### PR DESCRIPTION
Contao 5.7.8 is now compatible with `league/flysystem-bundle` version 3.7 (see https://github.com/contao/contao/pull/9902).