### PR TITLE
Add doctrine/orm 3.6.8 to conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/dbal": "2.9.* <2.9.3 || 3.3.0 || 3.5.0 || 3.7.0",
         "doctrine/doctrine-bundle": "2.6.0",
         "doctrine/doctrine-migrations-bundle": "<1.1",
-        "doctrine/orm": "<2.4",
+        "doctrine/orm": "<2.4 || 3.6.8",
         "doctrine/persistence": "1.3.2",
         "knplabs/knp-menu-bundle": "3.4.0",
         "knplabs/knp-time-bundle": "1.9.0",


### PR DESCRIPTION
Doctrine ORM 3.6.8 currently breaks cache:warmup, as reported in Slack by @Ainschy 
https://contao.slack.com/archives/CK4J0KNDB/p1785996314760309

There is already a related issue: https://github.com/doctrine/orm/issues/12547


```
07:57:06 CRITICAL  [console] Error thrown while running command "cache:warmup --env=prod --ansi". Message: "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher." ["exception" => BadMethodCallException { …},"command" => "cache:warmup --env=prod --ansi","message" => "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher."]

In GenerateSchemaEventArgs.php line 41:

  The setSchema() method requires the DBAL Schema::edit() API which is not av
  ailable in the current DBAL version. This feature requires doctrine/dbal ^4
  .5 or higher.


cache:warmup [--no-optional-warmers]

07:57:06 CRITICAL  [console] An error occurred while using the console. Message: "An error occurred while executing the "/opt/php-8.5/bin/php -dmemory_limit=1536M /web/vendor/contao/manager-bundle/bin/contao-console cache:warmup --env=prod --ansi" command: 07:57:06 CRITICAL  [console] Error thrown while running command "cache:warmup --env=prod --ansi". Message: "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher." ["exception" => BadMethodCallException { …},"command" => "cache:warmup --env=prod --ansi","message" => "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher."]

In GenerateSchemaEventArgs.php line 41:

  The setSchema() method requires the DBAL Schema::edit() API which is not av
  ailable in the current DBAL version. This feature requires doctrine/dbal ^4
  .5 or higher.


cache:warmup [--no-optional-warmers]

" ["exception" => RuntimeException { …},"message" => """  An error occurred while executing the "/opt/php-8.5/bin/php -dmemory_limit=1536M /web/vendor/contao/manager-bundle/bin/contao-console cache:warmup --env=prod --ansi" command: 07:57:06 \e[31mCRITICAL \e[39m \e[33m[console]\e[39m Error thrown while running command "cache:warmup --env=prod --ansi". Message: "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher." \e[0;38;5;208m[\e[m\e[0;38;5;208m"\e[38;5;113mexception\e[0;38;5;208m" => \e[38;5;38mBadMethodCallException\e[0;38;5;208m { …},\e[m\e[0;38;5;208m"\e[38;5;113mcommand\e[0;38;5;208m" => "\e[1;38;5;113mcache:warmup --env=prod --ansi\e[0;38;5;208m",\e[m\e[0;38;5;208m"\e[38;5;113mmessage\e[0;38;5;208m" => "\e[1;38;5;113mThe setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher.\e[0;38;5;208m"\e[m\e[0;38;5;208m]\e[m\n  \n  \e[33mIn GenerateSchemaEventArgs.php line 41:\e[39m\n  \e[37;41m                                                                               \e[39;49m\n  \e[37;41m  The setSchema() method requires the DBAL Schema::edit() API which is not av  \e[39;49m\n  \e[37;41m  ailable in the current DBAL version. This feature requires doctrine/dbal ^4  \e[39;49m\n  \e[37;41m  .5 or higher.                                                                \e[39;49m\n  \e[37;41m                                                                               \e[39;49m\n  \n  \e[32mcache:warmup [--no-optional-warmers]\e[39m\n  \n  """]

In ContaoSetupCommand.php line 156:

  An error occurred while executing the "/opt/php-8.5/bin/php -dmemory_limit=1536M /web/vendor/contao/manager-bundle/bin/contao-console cache:warmup --env=prod --ansi" command: 07:57:06 CRITICAL  [console] Error thrown while running command "cache:warmup --env=prod --ansi". Message
  : "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher." ["exception" => BadMethodCallException { …},[0;38;5;0[39;49m
  208m"command" => "cache:warmup --env=prod --ansi","message" => "The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires
   doctrine/dbal ^4.5 or higher."]

  In GenerateSchemaEventArgs.php line 41:

    The setSchema() method requires the DBAL Schema::edit() API which is not av
    ailable in the current DBAL version. This feature requires doctrine/dbal ^4
    .5 or higher.


  cache:warmup [--no-optional-warmers]


contao:setup

Script @php vendor/bin/contao-setup handling the post-update-cmd event returned with error code 1
```